### PR TITLE
Trying to extract UNSC Resolutions with various Python scraping frameworks

### DIFF
--- a/code/unsc-with-bs4-csssel.py
+++ b/code/unsc-with-bs4-csssel.py
@@ -1,0 +1,91 @@
+"""Using Beautiful Soup with CSS Selectors to collect UNSC Resolutions
+"""
+
+import time
+import requests
+from requests.compat import urljoin
+import bs4
+
+
+def get_year_urls():
+    """Return a list of (year_url, year) pairs
+    """
+    # WARNING: the final / is very important when doing urljoin below
+    base_url = 'http://www.un.org/en/sc/documents/resolutions/'
+    response = requests.get(base_url)
+    soup = bs4.BeautifulSoup(response.content, 'html.parser')
+    tables = soup.select('#content > table')
+    # It's a good idea to check you captured something
+    # and not more than you expected
+    assert len(tables) == 1
+
+    table = tables[0]
+    links = table.select('a')
+
+    out = []
+    for link in links:
+        year_url = urljoin(base_url, link.attrs['href'])
+        year = link.text
+        # As well as converting to a number, this validates the year text is
+        # what we expect
+        year = int(year)
+        out.append((year_url, year))
+
+    # Check we got something
+    assert len(out)
+    return out
+
+
+def get_resolutions_for_year(year_url, year):
+    """Return a list of dicts, each detailing 1 UNSC resolution from given year
+    """
+    response = requests.get(year_url)
+    soup = bs4.BeautifulSoup(response.content, 'html.parser')
+    tables = soup.select('#content > table')
+    if year != 1960 and year != 1964:
+        # 1960 and 1964 have the entire page repeated twice!
+        # Let's just use the first copy...
+        assert len(tables) == 1
+
+    symbol_cells = tables[0].select('td:nth-of-type(1)')
+
+    out = []
+    for symbol_cell in symbol_cells:
+        links = symbol_cell.select('a')
+        if not links:
+            # http://www.un.org/en/sc/documents/resolutions/2013.shtml
+            # has a row which breaks our scraper. Skip it.
+            print('Found a cell that does not have a view link: ',
+                  symbol_cell.text)
+            continue
+        url = links[0].attrs['href']
+        title_cell = symbol_cell.find_next_sibling()
+        out.append({'year': year,
+                    'title': title_cell.text,
+                    'symbol': symbol_cell.text,
+                    'url': urljoin(year_url, url)})
+    return out
+
+
+def scrape_unsc_resolutions():
+    # Note that for some projects you might be scraping lots of data
+    # over a long time, and so might not want to store all the data in
+    # memory at the same time like this code does.
+    out = []
+    for year_url, year in get_year_urls():
+        time.sleep(0.01)
+        print('Processing:', year_url)
+        out += get_resolutions_for_year(year_url, year)
+    return out
+
+
+if __name__ == '__main__':
+    import csv
+
+    resolutions = scrape_unsc_resolutions()
+
+    with open('unsc-resolutions.csv') as out_file:
+        writer = csv.DictWriter(out_file, ['year', 'symbol', 'title', 'url'])
+        writer.writeheader()
+        for resolution in resolutions:
+            writer.writerow(resolution)

--- a/code/unsc-with-bs4-csssel.py
+++ b/code/unsc-with-bs4-csssel.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
 
     resolutions = scrape_unsc_resolutions()
 
-    with open('unsc-resolutions.csv') as out_file:
+    with open('unsc-resolutions.csv', 'w') as out_file:
         writer = csv.DictWriter(out_file, ['year', 'symbol', 'title', 'url'])
         writer.writeheader()
         for resolution in resolutions:

--- a/code/unsc-with-lxml-csssel.py
+++ b/code/unsc-with-lxml-csssel.py
@@ -1,0 +1,102 @@
+"""Using Beautiful tree with CSS Selectors to collect UNSC Resolutions
+"""
+
+import time
+import requests
+from requests.compat import urljoin
+from lxml import etree
+
+
+def inner_text(element):
+    return ''.join(element.itertext())
+
+
+def get_year_urls():
+    """Return a list of (year_url, year) pairs
+    """
+    # WARNING: the final / is very important when doing urljoin below
+    base_url = 'http://www.un.org/en/sc/documents/resolutions/'
+    response = requests.get(base_url)
+    tree = etree.HTML(response.content)
+    tables = tree.cssselect('#content > table')
+    # It's a good idea to check you captured something
+    # and not more than you expected
+    assert len(tables) == 1
+
+    table = tables[0]
+    links = table.cssselect('a')
+
+    out = []
+    for link in links:
+        year_url = urljoin(base_url, link.attrib['href'])
+        year = link.text
+        # As well as converting to a number, this validates the year text is
+        # what we expect
+        year = int(year)
+        out.append((year_url, year))
+
+    # Check we got something
+    assert len(out)
+    return out
+
+
+def get_resolutions_for_year(year_url, year):
+    """Return a list of dicts, each detailing 1 UNSC resolution from given year
+    """
+    response = requests.get(year_url)
+    tree = etree.HTML(response.content)
+    tables = tree.cssselect('#content > table')
+    if year != 1960 and year != 1964:
+        # 1960 and 1964 have the entire page repeated twice!
+        # Let's just use the first copy in all cases...
+        assert len(tables) == 1
+
+    rows = tables[0].cssselect('tr')
+
+    out = []
+    for row in rows:
+        cells = row.cssselect('td')
+        if len(cells) < 2:
+            # ignore the header
+            continue
+        symbol_cell = cells[0]
+        title_cell = cells[-1]
+        links = symbol_cell.cssselect('a')
+        if not links:
+            # http://www.un.org/en/sc/documents/resolutions/2013.shtml
+            # has a row which breaks our scraper. Skip it.
+            print('Found a cell that does not have a view link: ',
+                  inner_text(symbol_cell))
+            continue
+        url = links[0].attrib['href']
+        out.append({'year': year,
+                    'title': inner_text(title_cell),
+                    # TODO: whitespace needs cleaning in these!
+                    'symbol': inner_text(symbol_cell),
+                    'url': urljoin(year_url, url)})
+    assert len(out) > 1 or year == 1959
+    return out
+
+
+def scrape_unsc_resolutions():
+    # Note that for some projects you might be scraping lots of data
+    # over a long time, and so might not want to store all the data in
+    # memory at the same time like this code does.
+    out = []
+    for year_url, year in get_year_urls():
+        time.sleep(0.01)
+        print('Processing:', year_url)
+        out += get_resolutions_for_year(year_url, year)
+    return out
+
+
+if __name__ == '__main__':
+    import csv
+
+    resolutions = scrape_unsc_resolutions()
+
+    with open('unsc-resolutions.csv', 'w') as out_file:
+        writer = csv.DictWriter(out_file, ['year', 'symbol', 'title', 'url'])
+        writer.writeheader()
+        for resolution in resolutions:
+            writer.writerow(resolution)

--- a/code/unsc-with-webdriver-csssel.py
+++ b/code/unsc-with-webdriver-csssel.py
@@ -42,13 +42,19 @@ def get_resolutions_for_year(driver, year_url, year):
     tables = driver.find_elements_by_css_selector('#content > table')
     if year != 1960 and year != 1964:
         # 1960 and 1964 have the entire page repeated twice!
-        # Let's just use the first copy...
+        # Let's just use the first copy in all cases...
         assert len(tables) == 1
 
-    symbol_cells = tables[0].find_elements_by_css_selector('td:nth-of-type(1)')
+    rows = tables[0].find_elements_by_css_selector('tr')
 
     out = []
-    for symbol_cell in symbol_cells:
+    for row in rows:
+        cells = row.find_elements_by_css_selector('td')
+        if len(cells) < 2:
+            # ignore the header
+            continue
+        symbol_cell = cells[0]
+        title_cell = cells[-1]
         links = symbol_cell.find_elements_by_css_selector('a')
         if not links:
             # http://www.un.org/en/sc/documents/resolutions/2013.shtml
@@ -57,12 +63,11 @@ def get_resolutions_for_year(driver, year_url, year):
                   symbol_cell.text)
             continue
         url = links[0].get_attribute('href')
-        # TODO: Handle the 2014 quirky date column!!
-        title_cell = symbol_cell.get_property('nextElementSibling')
         out.append({'year': year,
                     'title': title_cell.text,
                     'symbol': symbol_cell.text,
                     'url': url})
+    assert len(out) > 1 or year == 1959
     return out
 
 


### PR DESCRIPTION
I've tried implementing a standalone scraper for the target suggested by the Library Carpentry folks (https://github.com/data-lessons/library-webscraping/issues/11).

Note that there are a few quirks here (to be expected for scraping manually-constructed pages):
* Most of the link HREFs are relative (e.g. `1980.shtml`) in the [index page](http://www.un.org/en/sc/documents/resolutions/) but others are absolute on the domain (e.g. `/en/sc/documents/resolutions/2015.shtml`)
* [2013](http://www.un.org/en/sc/documents/resolutions/2013.shtml) has an unusual quirk in its table where the first content row is actually column headers
* [1960](http://www.un.org/en/sc/documents/resolutions/1960.shtml) and [1964](http://www.un.org/en/sc/documents/resolutions/1964.shtml) include the entire page in duplicate!
* [2014](http://www.un.org/en/sc/documents/resolutions/2014.shtml) has a date column
* [2017](http://www.un.org/en/sc/documents/resolutions/2017.shtml) has a loose `</tr>`. this happens to break bs4's parsing with 'html.parser' engine, such that the data is not recoverable!
* Varying use of whitespace, particularly in resolution codes: `S/RES/1939  (2010)` vs `S/RES/2025 (2011)` vs `S/RES/2132\n    (2013)`
* It's possible I missed other quirks because they didn't upset my scraping technique

Implemented so far:
* [x] Beautiful Soup with CSS Selectors
* [x] selenium.webdriver with CSS Selectors
* [ ] Scrapy with CSS Selectors
* [ ] lxml with CSS Selectors
* [ ] selenium.webdriver with XPath
* [ ] Scrapy with XPath
* [ ] lxml with XPath
* [ ] pandas.read_html ?